### PR TITLE
Increase chunk size for greater reliability

### DIFF
--- a/Source/IntuneAppBuilder/Services/IntuneAppPublishingService.cs
+++ b/Source/IntuneAppBuilder/Services/IntuneAppPublishingService.cs
@@ -198,7 +198,7 @@ namespace IntuneAppBuilder.Services
             var blockCount = 0;
             var blockIds = new List<string>();
 
-            const int chunkSize = 5 * 1024 * 1024;
+            const int chunkSize = 25 * 1024 * 1024;
             package.Data.Seek(0, SeekOrigin.Begin);
             var lastBlockId = (Math.Ceiling((double)package.Data.Length / chunkSize) - 1).ToString("0000");
             foreach (var chunk in Chunk(package.Data, chunkSize, false))


### PR DESCRIPTION
Azure storage APIs seem to be unreliable once a file has more than 100 parts)