### PR TITLE
Increase dotnet-version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     branches:
       - master
 
@@ -28,15 +28,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
+
       - name: Set Up .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - name: dotnet restore
         run: dotnet restore --verbosity $env:Verbosity
-      
+
       - name: dotnet build
         run: $env:GITHUB_REF = '${{ github.head_ref }}'; dotnet build --configuration $env:BuildConfiguration --verbosity $env:Verbosity --no-restore
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
 mode: Mainline
-next-version: 3.0.0
+next-version: 3.0.1


### PR DESCRIPTION
The GitHub action for the repository seemed to have been disabled due to inactivity. I re-enabled it, and this PR includes a fix to get the build passing again