### PR TITLE
Fix continuous integration 'schedule' events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: actions/checkout@v3
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Run the same checkout job for 'schedule' events as is run for 'push' events by adjusting an if condition