### PR TITLE
Upgrade azure identity to 1.11.4

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
 mode: Mainline
-next-version: 3.3.0
+next-version: 3.4.0

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
 mode: Mainline
-next-version: 3.4.0
+next-version: 3.3.1

--- a/Source/IntuneAppBuilder/IntuneAppBuilder.csproj
+++ b/Source/IntuneAppBuilder/IntuneAppBuilder.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0"/>
         <PackageReference Include="Microsoft.Graph.Beta" Version="5.56.0-preview"/>
-        <PackageReference Include="Azure.Identity" Version="1.11.0"/>
+        <PackageReference Include="Azure.Identity" Version="1.11.4"/>
         <PackageReference Include="WindowsAzure.Storage" Version="9.3.3"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
     </ItemGroup>


### PR DESCRIPTION
To address the following build error:

``` 
error NU1902: Warning As Error: Package 'Azure.Identity' 1.11.0 has a known moderate severity vulnerability
```